### PR TITLE
fix: sync package.json version and automate CHANGELOG updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,39 @@ jobs:
           npm version $NEW_VERSION --no-git-tag-version
           echo "Updated package.json to version $NEW_VERSION"
 
+      - name: Update CHANGELOG.md
+        run: |
+          VERSION="${{ steps.new_version.outputs.version }}"
+          DATE=$(date +%Y-%m-%d)
+          
+          # Get commit title
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TITLE="Manual release: ${{ steps.version.outputs.bump }} version bump"
+          else
+            TITLE=$(echo "${{ github.event.head_commit.message }}" | head -n 1)
+          fi
+          
+          # Create temporary file with new entry
+          cat > /tmp/changelog_entry.txt << EOF
+## [$VERSION] - $DATE
+
+### Changed
+- $TITLE
+
+EOF
+          
+          # Insert after "## [Unreleased]" line
+          if grep -q "## \[Unreleased\]" CHANGELOG.md; then
+            awk '/## \[Unreleased\]/ {print; print ""; system("cat /tmp/changelog_entry.txt"); next}1' CHANGELOG.md > /tmp/CHANGELOG.md.new
+            mv /tmp/CHANGELOG.md.new CHANGELOG.md
+          else
+            # If no Unreleased section, add at the top after header
+            awk 'NR==1,/^$/ {print; if(/^$/ && !done) {system("cat /tmp/changelog_entry.txt"); done=1}; next}1' CHANGELOG.md > /tmp/CHANGELOG.md.new
+            mv /tmp/CHANGELOG.md.new CHANGELOG.md
+          fi
+          
+          echo "Updated CHANGELOG.md with version $VERSION"
+
       - name: Clean up existing tag
         run: |
           TAG="v${{ steps.new_version.outputs.version }}"
@@ -152,12 +185,19 @@ jobs:
           git push origin :refs/tags/$TAG 2>/dev/null || true
           echo "Cleaned up any existing $TAG tag"
 
-      - name: Create release tag
+      - name: Create release tag and push version bump
         run: |
-          # Commit the version bump to create a proper tag
-          git add package.json package-lock.json
+          # Commit the version bump and changelog
+          git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore: release v${{ steps.new_version.outputs.version }}" || true
+          
+          # Create annotated tag
           git tag -a v${{ steps.new_version.outputs.version }} -m "Release v${{ steps.new_version.outputs.version }}"
+          
+          # Push the version bump commit to main
+          git push origin HEAD:main
+          
+          # Push the tag
           git push origin v${{ steps.new_version.outputs.version }}
 
       - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,20 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-01-26
+
+### Fixed
+- Parse only commit title for version detection to avoid PR template syntax errors
+- Fixed shell interpretation errors in CI workflow from PR template content
+
+## [0.1.0] - 2025-01-25
+
+### Added
 - Initial release
+- Interactive MCP explorer for VS Code
+- Support for both global and local MCP servers
+- Tree view with server details, tools, prompts, and resources
+- Real-time server status monitoring
+- Start/Stop/Restart controls for MCP servers
+- Filter capabilities (Global/Local/Both)
+- Webview-based detailed information panel

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mcp-lens",
   "displayName": "MCP Lens",
   "description": "MCP Lens — an interactive VSCode tool for exploring both global and local MCPs effortlessly.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "giri-jeedigunta",
   "icon": "resources/mcp-lens-v1.png",
   "license": "MIT",


### PR DESCRIPTION
## Description

- Update package.json to 0.1.1 to match published marketplace version
- Modify workflow to push version bump commits back to main branch
- Add automatic CHANGELOG.md updates on each release
- Populate CHANGELOG with v0.1.0 and v0.1.1 release notes
- Ensures package.json, CHANGELOG.md, git tags, and marketplace stay in sync


### PR Title Validation

- [x] PR title pattern: `{type}: Description` or `{type}: [#{GITHUB-ISSUE-ID}] Description`


## Type of Change
- [ ] 🎯 Feature (new functionality)
- [X] 🐛 Bug fix
- [ ] 📚 Documentation
- [X] ♻️ Refactoring
- [ ] 🧪 Tests
- [ ] 🔧 Chore (maintenance)

## Testing
- [ ] Tested locally
- [ ] No breaking changes

## Related Issues
<!-- Link related issues: Fixes #123, Related to #456 -->
